### PR TITLE
Option that allows user to override the capture button key mapped with Windows Screenshot shortcut Win + PrtScrn

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -79,5 +79,9 @@
 		<!-- Have ShowAsXInput as false if using this -->
 		<!-- Default: false -->
 		<add key="ShowAsDS4" value="true"/>
+
+		<!-- Overrides capture button key mapped with Windows Screenshot shortcut Win + PrtScrn -->
+		<!-- Default: false -->
+		<add key="WindowsScreenshot" value="false"/>
 	</appSettings>
 </configuration>

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -232,6 +232,7 @@ namespace BetterJoyForCemu {
 
 		bool showAsXInput = Boolean.Parse(ConfigurationManager.AppSettings["ShowAsXInput"]);
 		bool showAsDS4 = Boolean.Parse(ConfigurationManager.AppSettings["ShowAsDS4"]);
+		bool windowsScreenshot = Boolean.Parse(ConfigurationManager.AppSettings["WindowsScreenshot"]);
 
 		public MainForm form;
 
@@ -540,7 +541,11 @@ namespace BetterJoyForCemu {
 			if (s.StartsWith("key_")) {
 				WindowsInput.Events.KeyCode key = (WindowsInput.Events.KeyCode)Int32.Parse(s.Substring(4));
 				if (click) {
-					WindowsInput.Simulate.Events().Click(key).Invoke();
+					if (s == Config.Value("capture") && windowsScreenshot) {
+						WindowsInput.Simulate.Events().ClickChord(WindowsInput.Events.KeyCode.LWin, WindowsInput.Events.KeyCode.PrintScreen).Invoke();
+					} else {
+						WindowsInput.Simulate.Events().Click(key).Invoke();
+					}
 				} else {
 					if (up) {
 						WindowsInput.Simulate.Events().Release(key).Invoke();


### PR DESCRIPTION
Hi! I implemented this feature following the second approach. What do you guys think? Looks good to me.

![image](https://user-images.githubusercontent.com/18970657/79693222-c5204b80-823f-11ea-8e98-2de02902879c.png)
