### PR TITLE
JoyCons power-off feature

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -79,5 +79,11 @@
 		<!-- Have ShowAsXInput as false if using this -->
 		<!-- Default: false -->
 		<add key="ShowAsDS4" value="false"/>
+		<!-- Automatically power off joycons at program exit -->
+		<!-- Default: false -->
+		<add key="AutoPowerOff" value="false" />
+		<!-- Power off joycons when Capture (left only) or Home (right only or combined) buttons are pressed for a long interval (2s) -->
+		<!-- Default: false -->
+		<add key="HomeLongPowerOff" value="false" />
 	</appSettings>
 </configuration>

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -76,6 +76,7 @@ namespace BetterJoyForCemu {
 		private bool[] buttons_up = new bool[20];
 		private bool[] buttons = new bool[20];
 		private bool[] down_ = new bool[20];
+		private long[] buttons_down_timestamp = new long[20];
 
 		private float[] stick = { 0, 0 };
 		private float[] stick2 = { 0, 0 };
@@ -250,6 +251,8 @@ namespace BetterJoyForCemu {
 			imu_enabled = imu;
 			do_localize = localize;
 			rumble_obj = new Rumble(160, 320, 0);
+			for (int i = 0; i < buttons_down_timestamp.Length; i++)
+				buttons_down_timestamp[i] = -1;
 			filterweight = alpha;
 			isLeft = left;
 
@@ -802,11 +805,15 @@ namespace BetterJoyForCemu {
 					buttons[(int)Button.MINUS] = other.buttons[(int)Button.MINUS];
 				}
 
+				long timestamp = Stopwatch.GetTimestamp();
+
 				lock (buttons_up) {
 					lock (buttons_down) {
 						for (int i = 0; i < buttons.Length; ++i) {
 							buttons_up[i] = (down_[i] & !buttons[i]);
 							buttons_down[i] = (!down_[i] & buttons[i]);
+							if (down_[i] != buttons[i])
+								buttons_down_timestamp[i] = (buttons[i] ? timestamp : -1);
 						}
 					}
 				}

--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -255,6 +255,7 @@ namespace BetterJoyForCemu {
 				AppendTextBox("Error writing app settings.\r\n");
 			}
 
+			ConfigurationManager.AppSettings["AutoPowerOff"] = "false";  // Prevent joycons poweroff when applying settings
 			Application.Restart();
 			Environment.Exit(0);
 		}

--- a/BetterJoyForCemu/Program.cs
+++ b/BetterJoyForCemu/Program.cs
@@ -300,7 +300,10 @@ namespace BetterJoyForCemu {
 
 		public void OnApplicationQuit() {
 			foreach (Joycon v in j) {
-				v.Detach();
+				if (Boolean.Parse(ConfigurationManager.AppSettings["AutoPowerOff"]))
+					v.PowerOff();
+				else
+					v.Detach();
 
 				if (v.xin != null) {
 					v.xin.Disconnect();


### PR DESCRIPTION
Hi.

I've implemented a couple of simple power-off feature(s) for JoyCons.

1. **AutoPowerOff**: automatically power off joycons at program exit
2. **HomeLongPowerOff**: power off joycons when Home (right only joycon or combined joycons) or Capture (left only joycon) button is pressed for a long interval (hard-coded to 2s)

In order to detect long-presses of the Home/Capture buttons I've added some basic timestamp tracking for when buttons are pressed.

![feature-joycons-poweroff](https://user-images.githubusercontent.com/63293773/81475905-74788e80-91fe-11ea-9a9a-1351cfe14b4d.png)

Tested only on JoyCons, not Pro nor SNES controller.