### PR TITLE
new option to calibrate controllers in BetterJoy

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -35,7 +35,7 @@
         <add key="SwapXY" value="false" />
 
         <!--Allows for calibration of the controller's gyro. Adds a "Calibrate" button.-->
-        <!--When "true", click "Calibrate" button once to get gyro calibrate data.-->
+        <!--When "true", click the "Calibrate" button once to get gyro calibrate data.-->
         <!--When enabled, can only calibrate one controller at a time.-->
         <!--Default: true -->
         <add key="AllowCalibration" value="true" />

--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -34,6 +34,10 @@
         <!--On is "true"; off is "false". Default: false -->
         <add key="SwapXY" value="false" />
 
+        <!--Allows for calibrantion of the controller's gyro-->
+        <!--Default: true -->
+        <add key="AllowCalibration" value="true" />
+        
         <!--Allows use of gyroscope tilting to get full control of the slider values (big triggers)-->
         <!--Works on pro controller and joined joycons (pro controller case - triggers combined, joycons case - separate tilt)-->
         <!--Default: false -->

--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -34,7 +34,9 @@
         <!--On is "true"; off is "false". Default: false -->
         <add key="SwapXY" value="false" />
 
-        <!--Allows for calibrantion of the controller's gyro-->
+        <!--Allows for calibration of the controller's gyro. Adds a "Calibrate" button.-->
+        <!--When "true", click "Calibrate" button once to get gyro calibrate data.-->
+        <!--When enabled, can only calibrate one controller at a time.-->
         <!--Default: true -->
         <add key="AllowCalibration" value="true" />
         
@@ -59,9 +61,7 @@
         <!-- Default: false -->
         <add key="UseHIDG" value="false" />
 
-        <!-- Determines whether or not to enable (experimental - currently default controller to pro) support for 3rd-party controllers. Adds a "Calibrate" button. -->
-        <!-- When "true", click "Calibrate" button once to get gyro calibrate data. -->
-        <!-- When enabled, can only calibrate one controller at a time. -->
+        <!-- Determines whether or not to enable (experimental - currently default controller to pro) support for 3rd-party controllers. -->
         <!-- Default: false -->
         <add key="NonOriginalController" value="false" />
         <!-- The program will keep the HOME button LED ring light on at all times. -->

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -909,7 +909,7 @@ namespace BetterJoyForCemu {
                 acc_r[1] = (Int16)(report_buf[15 + n * 12] | ((report_buf[16 + n * 12] << 8) & 0xff00));
                 acc_r[2] = (Int16)(report_buf[17 + n * 12] | ((report_buf[18 + n * 12] << 8) & 0xff00));
 
-                if (form.nonOriginal) {
+                if (form.allowCalibration) {
                     for (int i = 0; i < 3; ++i) {
                         switch (i) {
                             case 0:

--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -16,6 +16,7 @@ using System.Xml.Linq;
 namespace BetterJoyForCemu {
     public partial class MainForm : Form {
         public bool nonOriginal = Boolean.Parse(ConfigurationManager.AppSettings["NonOriginalController"]);
+        public bool allowCalibration = Boolean.Parse(ConfigurationManager.AppSettings["AllowCalibration"]);
         public List<Button> con, loc;
         public bool calibrate;
         public List<KeyValuePair<string, float[]>> caliData;
@@ -32,7 +33,7 @@ namespace BetterJoyForCemu {
 
             InitializeComponent();
 
-            if (!nonOriginal)
+            if (!allowCalibration)
                 AutoCalibrate.Hide();
 
             con = new List<Button> { con1, con2, con3, con4 };

--- a/BetterJoyForCemu/Program.cs
+++ b/BetterJoyForCemu/Program.cs
@@ -315,7 +315,7 @@ namespace BetterJoyForCemu {
                     }
 
                     jc.Begin();
-                    if (form.nonOriginal) {
+                    if (form.allowCalibration) {
                         jc.getActiveData();
                     }
 


### PR DESCRIPTION
This adds a new option to calibrate controllers in BetterJoy.
Separates the calibration code from the Non-Original Controller setting.

Do not merge yet, this still needs to be tested by someone with access to Joy-cons.
Tested with the Switch Pro Controller.

Should be merged with #520 as it also contains calibration fixes.

