### PR TITLE
Inital change for #518

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -30,7 +30,9 @@
         <add key="EnableShakeInput" value="false" />
         <!--How sensitve the shake detection should be. Default: 10-->
         <add key="ShakeInputSensitivity" value="10" />
-        <!--How often should the shake input run in milliseconds. Default: 200 -->
+        <!--How often should the shake input run in milliseconds. -->
+        <!--Don't set this lower than 15 -->
+        <!-- Default: 200 -->
         <add key="ShakeInputDelay" value="200" />
         
         <!--Swap A-B buttons; if on, this mimicks the (half of) Xbox layout by the button name, rather than by the physical layout.-->

--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -25,6 +25,14 @@
         <!--On is "true"; off is "false". Default: true -->
         <add key="EnableRumble" value="true" />
 
+        <!--Enables a input when shaking a controller, only works with DS4 for now, replaces the touchpad input (Button 13 on DirectInput)-->
+        <!--On is "true"; off is "false". Default: false -->
+        <add key="EnableShakeInput" value="false" />
+        <!--How sensitve the shake detection should be. Default: 10-->
+        <add key="ShakeInputSensitivity" value="10" />
+        <!--How often should the shake input run in milliseconds. Default: 200 -->
+        <add key="ShakeInputDelay" value="200" />
+        
         <!--Swap A-B buttons; if on, this mimicks the (half of) Xbox layout by the button name, rather than by the physical layout.-->
         <!--Also swaps buttons when using "Also use for buttons/axes"-->
         <!--On is "true"; off is "false". Default: false -->

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -21,19 +21,39 @@ namespace BetterJoyForCemu {
 			return "0";
 		}
 
-		public static void Init(List<KeyValuePair<string, float[]>> caliData) {
+        // Helper function to count how many lines are in a file
+        static long CountLinesInFile(string f) {
+            // Zero based count
+            long count = -1;
+            using (StreamReader r = new StreamReader(f)) {
+                string line;
+                while ((line = r.ReadLine()) != null) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        public static void Init(List<KeyValuePair<string, float[]>> caliData) {
 			foreach (string s in new string[] { "ProgressiveScan", "StartInTray", "capture", "home", "sl_l", "sl_r", "sr_l", "sr_r", "shake", "reset_mouse", "active_gyro" })
 				variables[s] = GetDefaultValue(s);
 
-			if (File.Exists(PATH)) {
-				int lineNO = -1;
+            if (File.Exists(PATH)) {
+
+                // Reset settings file if old settings
+                if (CountLinesInFile(PATH) < settingsNum) {
+                    File.Delete(PATH);
+                    Init(caliData);
+                    return;
+                }
+
 				using (StreamReader file = new StreamReader(PATH)) {
 					string line = String.Empty;
-
-					while ((line = file.ReadLine()) != null) {
+                    int lineNO = 0;
+                    while ((line = file.ReadLine()) != null) {
 						string[] vs = line.Split();
-						try {
-							if (lineNO < settingsNum) { // load in basic settings
+                        try {
+                            if (lineNO < settingsNum) { // load in basic settings
 								variables[vs[0]] = vs[1];
 							} else { // load in calibration presets
 								caliData.Clear();
@@ -50,16 +70,8 @@ namespace BetterJoyForCemu {
 								}
 							}
 						} catch { }
-						lineNO++;
-					}
-
-
-				}
-
-				// if old settings
-				if (lineNO < settingsNum) {
-					File.Delete(PATH);
-					Init(caliData);
+                        lineNO++;
+                    }
 				}
 			} else {
 				using (StreamWriter file = new StreamWriter(PATH)) {

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -121,8 +121,8 @@ namespace BetterJoyForCemu {
 				if (i == 0) space = "";
 				caliStr += space + caliData[i].Key + "," + String.Join(",", caliData[i].Value);
 			}
-		    txt[settingsNum] = caliStr;
-		    File.WriteAllLines(PATH, txt);
+            txt[settingsNum] = caliStr;
+            File.WriteAllLines(PATH, txt);
 		}
 
 		public static void Save() {

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -7,7 +7,7 @@ namespace BetterJoyForCemu {
 		const string PATH = "settings";
 		static Dictionary<string, string> variables = new Dictionary<string, string>();
 
-		const int settingsNum = 10; // currently - ProgressiveScan, StartInTray + special buttons
+		const int settingsNum = 11; // currently - ProgressiveScan, StartInTray + special buttons
 
 		public static string GetDefaultValue(string s) {
 			switch (s) {
@@ -22,7 +22,7 @@ namespace BetterJoyForCemu {
 		}
 
 		public static void Init(List<KeyValuePair<string, float[]>> caliData) {
-			foreach (string s in new string[] { "ProgressiveScan", "StartInTray", "capture", "home", "sl_l", "sl_r", "sr_l", "sr_r", "reset_mouse", "active_gyro" })
+			foreach (string s in new string[] { "ProgressiveScan", "StartInTray", "capture", "home", "sl_l", "sl_r", "sr_l", "sr_r", "shake", "reset_mouse", "active_gyro" })
 				variables[s] = GetDefaultValue(s);
 
 			if (File.Exists(PATH)) {

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -22,6 +22,7 @@ namespace BetterJoyForCemu {
 		}
 
         // Helper function to count how many lines are in a file
+        // https://www.dotnetperls.com/line-count
         static long CountLinesInFile(string f) {
             // Zero based count
             long count = -1;

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -57,7 +57,7 @@ namespace BetterJoyForCemu {
 				}
 
 				// if old settings
-				if (lineNO < settingsNum) {
+				if (lineNO < settingsNum + 1) {
 					File.Delete(PATH);
 					Init(caliData);
 				}

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -121,8 +121,8 @@ namespace BetterJoyForCemu {
 				if (i == 0) space = "";
 				caliStr += space + caliData[i].Key + "," + String.Join(",", caliData[i].Value);
 			}
-			txt[settingsNum] = caliStr;
-			File.WriteAllLines(PATH, txt);
+		    txt[settingsNum] = caliStr;
+		    File.WriteAllLines(PATH, txt);
 		}
 
 		public static void Save() {

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -26,7 +26,7 @@ namespace BetterJoyForCemu {
 				variables[s] = GetDefaultValue(s);
 
 			if (File.Exists(PATH)) {
-				int lineNO = 0;
+				int lineNO = -1;
 				using (StreamReader file = new StreamReader(PATH)) {
 					string line = String.Empty;
 
@@ -57,7 +57,7 @@ namespace BetterJoyForCemu {
 				}
 
 				// if old settings
-				if (lineNO < settingsNum + 1) {
+				if (lineNO < settingsNum) {
 					File.Delete(PATH);
 					Init(caliData);
 				}

--- a/BetterJoyForCemu/Config.cs
+++ b/BetterJoyForCemu/Config.cs
@@ -21,40 +21,40 @@ namespace BetterJoyForCemu {
 			return "0";
 		}
 
-        // Helper function to count how many lines are in a file
-        // https://www.dotnetperls.com/line-count
-        static long CountLinesInFile(string f) {
-            // Zero based count
-            long count = -1;
-            using (StreamReader r = new StreamReader(f)) {
-                string line;
-                while ((line = r.ReadLine()) != null) {
-                    count++;
-                }
-            }
-            return count;
-        }
+		// Helper function to count how many lines are in a file
+		// https://www.dotnetperls.com/line-count
+		static long CountLinesInFile(string f) {
+			// Zero based count
+			long count = -1;
+			using (StreamReader r = new StreamReader(f)) {
+				string line;
+				while ((line = r.ReadLine()) != null) {
+					count++;
+				}
+			}
+			return count;
+		}
 
-        public static void Init(List<KeyValuePair<string, float[]>> caliData) {
+		public static void Init(List<KeyValuePair<string, float[]>> caliData) {
 			foreach (string s in new string[] { "ProgressiveScan", "StartInTray", "capture", "home", "sl_l", "sl_r", "sr_l", "sr_r", "shake", "reset_mouse", "active_gyro" })
 				variables[s] = GetDefaultValue(s);
 
-            if (File.Exists(PATH)) {
+			if (File.Exists(PATH)) {
 
-                // Reset settings file if old settings
-                if (CountLinesInFile(PATH) < settingsNum) {
-                    File.Delete(PATH);
-                    Init(caliData);
-                    return;
-                }
+				// Reset settings file if old settings
+				if (CountLinesInFile(PATH) < settingsNum) {
+					File.Delete(PATH);
+					Init(caliData);
+					return;
+				}
 
 				using (StreamReader file = new StreamReader(PATH)) {
 					string line = String.Empty;
-                    int lineNO = 0;
-                    while ((line = file.ReadLine()) != null) {
+					int lineNO = 0;
+					while ((line = file.ReadLine()) != null) {
 						string[] vs = line.Split();
-                        try {
-                            if (lineNO < settingsNum) { // load in basic settings
+						try {
+							if (lineNO < settingsNum) { // load in basic settings
 								variables[vs[0]] = vs[1];
 							} else { // load in calibration presets
 								caliData.Clear();
@@ -71,8 +71,8 @@ namespace BetterJoyForCemu {
 								}
 							}
 						} catch { }
-                        lineNO++;
-                    }
+						lineNO++;
+					}
 				}
 			} else {
 				using (StreamWriter file = new StreamWriter(PATH)) {
@@ -121,8 +121,8 @@ namespace BetterJoyForCemu {
 				if (i == 0) space = "";
 				caliStr += space + caliData[i].Key + "," + String.Join(",", caliData[i].Value);
 			}
-            txt[settingsNum] = caliStr;
-            File.WriteAllLines(PATH, txt);
+			txt[settingsNum] = caliStr;
+			File.WriteAllLines(PATH, txt);
 		}
 
 		public static void Save() {

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -696,6 +696,11 @@ namespace BetterJoyForCemu {
             SimulateContinous((int)Button.CAPTURE, Config.Value("capture"));
             SimulateContinous((int)Button.HOME, Config.Value("home"));
 
+            // Query if controller was shaked, if it has then click on mapped key.
+            if (hasBeenShaked) {
+                Simulate(Config.Value("shake"), true, false);
+            }
+
             if (isLeft) {
                 if (buttons_down[(int)Button.SL])
                     Simulate(Config.Value("sl_l"), false, false);
@@ -1340,7 +1345,6 @@ namespace BetterJoyForCemu {
             var stick2 = input.stick2;
             var sliderVal = input.sliderVal;
 
-            var hasShaked = input.hasBeenShaked;
 
             if (isPro) {
                 output.cross = buttons[(int)(!swapAB ? Button.B : Button.A)];
@@ -1371,10 +1375,7 @@ namespace BetterJoyForCemu {
                 output.share = buttons[(int)Button.MINUS];
                 output.options = buttons[(int)Button.PLUS];
                 output.ps = buttons[(int)Button.HOME];
-
-                // Maps shake input to DS4 touchpad (Button 13 on DirectInput)
-                output.touchpad = input.form.shakeInputEnabled ? hasShaked : buttons[(int)Button.CAPTURE];
-
+                output.touchpad = buttons[(int)Button.CAPTURE];
                 output.shoulder_left = buttons[(int)Button.SHOULDER_1];
                 output.shoulder_right = buttons[(int)Button.SHOULDER2_1];
                 output.thumb_left = buttons[(int)Button.STICK];

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -590,15 +590,15 @@ namespace BetterJoyForCemu {
                     hasShaked = true;
 
                     // Mapped shake key down
-                    Simulate(Config.Value("shake"), false, true);
+                    Simulate(Config.Value("shake"), false, false);
                     DebugPrint("Shaked at time: " + shakedTime.ToString(), DebugType.SHAKE);
                 }
 
-                // If controller was shaked then release mapped key, then reset hasShaked
-                if (hasShaked) {
+                // If controller was shaked then release mapped key after a small delay to simulate a button press, then reset hasShaked
+                if (hasShaked && currentShakeTime >= shakedTime + 10) {
 
                     // Mapped shake key up
-                    Simulate(Config.Value("shake"), false, false);
+                    Simulate(Config.Value("shake"), false, true);
                     DebugPrint("Shake completed", DebugType.SHAKE);
 
                     hasShaked = false;

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -578,7 +578,7 @@ namespace BetterJoyForCemu {
 
         private readonly Stopwatch shakeTimer = Stopwatch.StartNew(); //Setup a timer for measuring shake in milliseconds
         private long shakedTime = 0;
-        private bool hasBeenShaked;
+        private bool hasShaked;
         void DetectShake() {
             if (form.shakeInputEnabled) {
                 long currentShakeTime = shakeTimer.ElapsedMilliseconds;
@@ -587,14 +587,16 @@ namespace BetterJoyForCemu {
                 bool isShaking = GetAccel().LengthSquared() >= form.shakeSesitivity;
                 if (isShaking && currentShakeTime >= shakedTime + form.shakeDelay || isShaking && shakedTime == 0) {
                     shakedTime = currentShakeTime;
-                    hasBeenShaked = true;
+                    hasShaked = true;
+                    Simulate(Config.Value("shake"), false, true);
                     DebugPrint("Shaked at time: " + shakedTime.ToString(), DebugType.SHAKE);
                 }
 
-                // Reset shake boolean 
-                if (currentShakeTime >= shakedTime + form.shakeDelay / 2 && hasBeenShaked) {
-                    hasBeenShaked = false;
+                // If controller was shaked then click on mapped key, then reset hasShaked
+                if (hasShaked) {
+                    Simulate(Config.Value("shake"), false, false);
                     DebugPrint("Shake completed", DebugType.SHAKE);
+                    hasShaked = false;
                 }
 
                 // Reset shake timer every 10 seconds
@@ -695,11 +697,6 @@ namespace BetterJoyForCemu {
                 Simulate(Config.Value("home"));
             SimulateContinous((int)Button.CAPTURE, Config.Value("capture"));
             SimulateContinous((int)Button.HOME, Config.Value("home"));
-
-            // Query if controller was shaked, if it has then click on mapped key.
-            if (hasBeenShaked) {
-                Simulate(Config.Value("shake"), true, false);
-            }
 
             if (isLeft) {
                 if (buttons_down[(int)Button.SL])

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -589,13 +589,15 @@ namespace BetterJoyForCemu {
                     shakedTime = currentShakeTime;
                     hasShaked = true;
 
+                    // Mapped shake key down
                     Simulate(Config.Value("shake"), false, true);
                     DebugPrint("Shaked at time: " + shakedTime.ToString(), DebugType.SHAKE);
                 }
 
-                // If controller was shaked then click on mapped key, then reset hasShaked
+                // If controller was shaked then release mapped key, then reset hasShaked
                 if (hasShaked) {
 
+                    // Mapped shake key up
                     Simulate(Config.Value("shake"), false, false);
                     DebugPrint("Shake completed", DebugType.SHAKE);
 

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -604,11 +604,6 @@ namespace BetterJoyForCemu {
                     hasShaked = false;
                 }
 
-                // Reset shake timer every 10 seconds
-                if (shakeTimer.ElapsedMilliseconds >= 10000) {
-                    shakeTimer.Restart();
-                    shakedTime = -1;
-                }
             } else {
                 shakeTimer.Stop();
                 return;
@@ -1346,7 +1341,6 @@ namespace BetterJoyForCemu {
             var stick = input.stick;
             var stick2 = input.stick2;
             var sliderVal = input.sliderVal;
-
 
             if (isPro) {
                 output.cross = buttons[(int)(!swapAB ? Button.B : Button.A)];

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -526,7 +526,6 @@ namespace BetterJoyForCemu {
                 // Process packets as soon as they come
                 for (int n = 0; n < 3; n++) {
                     ExtractIMUValues(raw_buf, n);
-                    DetectShake();
 
                     byte lag = (byte)Math.Max(0, raw_buf[1] - ts_en - 3);
                     if (n == 0) {
@@ -596,11 +595,9 @@ namespace BetterJoyForCemu {
 
                 // If controller was shaked then release mapped key after a small delay to simulate a button press, then reset hasShaked
                 if (hasShaked && currentShakeTime >= shakedTime + 10) {
-
                     // Mapped shake key up
                     Simulate(Config.Value("shake"), false, true);
                     DebugPrint("Shake completed", DebugType.SHAKE);
-
                     hasShaked = false;
                 }
 
@@ -690,6 +687,8 @@ namespace BetterJoyForCemu {
                     return;
                 }
             }
+
+            DetectShake();
 
             if (buttons_down[(int)Button.CAPTURE])
                 Simulate(Config.Value("capture"));

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -588,14 +588,17 @@ namespace BetterJoyForCemu {
                 if (isShaking && currentShakeTime >= shakedTime + form.shakeDelay || isShaking && shakedTime == 0) {
                     shakedTime = currentShakeTime;
                     hasShaked = true;
+
                     Simulate(Config.Value("shake"), false, true);
                     DebugPrint("Shaked at time: " + shakedTime.ToString(), DebugType.SHAKE);
                 }
 
                 // If controller was shaked then click on mapped key, then reset hasShaked
                 if (hasShaked) {
+
                     Simulate(Config.Value("shake"), false, false);
                     DebugPrint("Shake completed", DebugType.SHAKE);
+
                     hasShaked = false;
                 }
 

--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -22,6 +22,9 @@ namespace BetterJoyForCemu {
         private Timer countDown;
         private int count;
         public List<int> xG, yG, zG, xA, yA, zA;
+        public bool shakeInputEnabled = Boolean.Parse(ConfigurationManager.AppSettings["EnableShakeInput"]);
+        public float shakeSesitivity = float.Parse(ConfigurationManager.AppSettings["ShakeInputSensitivity"]);
+        public float shakeDelay = float.Parse(ConfigurationManager.AppSettings["ShakeInputDelay"]);
 
         public MainForm() {
             xG = new List<int>(); yG = new List<int>(); zG = new List<int>();

--- a/BetterJoyForCemu/Reassign.Designer.cs
+++ b/BetterJoyForCemu/Reassign.Designer.cs
@@ -79,226 +79,248 @@ namespace BetterJoyForCemu {
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent() {
-			this.components = new System.ComponentModel.Container();
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Reassign));
-			this.btn_capture = new BetterJoyForCemu.SplitButton();
-			this.lbl_capture = new System.Windows.Forms.Label();
-			this.lbl_home = new System.Windows.Forms.Label();
-			this.btn_home = new BetterJoyForCemu.SplitButton();
-			this.lbl_sl_l = new System.Windows.Forms.Label();
-			this.btn_sl_l = new BetterJoyForCemu.SplitButton();
-			this.lbl_sr_l = new System.Windows.Forms.Label();
-			this.btn_sr_l = new BetterJoyForCemu.SplitButton();
-			this.lbl_sl_r = new System.Windows.Forms.Label();
-			this.btn_sl_r = new BetterJoyForCemu.SplitButton();
-			this.lbl_sr_r = new System.Windows.Forms.Label();
-			this.btn_sr_r = new BetterJoyForCemu.SplitButton();
-			this.btn_close = new Button();
-			this.btn_apply = new Button();
-			this.tip_reassign = new System.Windows.Forms.ToolTip(this.components);
-			this.lbl_reset_mouse = new System.Windows.Forms.Label();
-			this.btn_reset_mouse = new BetterJoyForCemu.SplitButton();
-			this.lbl_activate_gyro = new System.Windows.Forms.Label();
-			this.btn_active_gyro = new SplitButton();
-			this.SuspendLayout();
-			// 
-			// btn_capture
-			// 
-			this.btn_capture.Location = new System.Drawing.Point(105, 12);
-			this.btn_capture.Name = "btn_capture";
-			this.btn_capture.Size = new System.Drawing.Size(75, 23);
-			this.btn_capture.TabIndex = 0;
-			this.btn_capture.UseVisualStyleBackColor = true;
-			// 
-			// lbl_capture
-			// 
-			this.lbl_capture.AutoSize = true;
-			this.lbl_capture.Location = new System.Drawing.Point(15, 17);
-			this.lbl_capture.Name = "lbl_capture";
-			this.lbl_capture.Size = new System.Drawing.Size(44, 13);
-			this.lbl_capture.TabIndex = 2;
-			this.lbl_capture.Text = "Capture";
-			this.lbl_capture.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// lbl_home
-			// 
-			this.lbl_home.AutoSize = true;
-			this.lbl_home.Location = new System.Drawing.Point(15, 46);
-			this.lbl_home.Name = "lbl_home";
-			this.lbl_home.Size = new System.Drawing.Size(35, 13);
-			this.lbl_home.TabIndex = 4;
-			this.lbl_home.Text = "Home";
-			this.lbl_home.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_home
-			// 
-			this.btn_home.Location = new System.Drawing.Point(105, 41);
-			this.btn_home.Name = "btn_home";
-			this.btn_home.Size = new System.Drawing.Size(75, 23);
-			this.btn_home.TabIndex = 3;
-			this.btn_home.UseVisualStyleBackColor = true;
-			// 
-			// lbl_sl_l
-			// 
-			this.lbl_sl_l.AutoSize = true;
-			this.lbl_sl_l.Location = new System.Drawing.Point(15, 75);
-			this.lbl_sl_l.Name = "lbl_sl_l";
-			this.lbl_sl_l.Size = new System.Drawing.Size(78, 13);
-			this.lbl_sl_l.TabIndex = 6;
-			this.lbl_sl_l.Text = "SL Left Joycon";
-			this.lbl_sl_l.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_sl_l
-			// 
-			this.btn_sl_l.Location = new System.Drawing.Point(105, 70);
-			this.btn_sl_l.Name = "btn_sl_l";
-			this.btn_sl_l.Size = new System.Drawing.Size(75, 23);
-			this.btn_sl_l.TabIndex = 5;
-			this.btn_sl_l.UseVisualStyleBackColor = true;
-			// 
-			// lbl_sr_l
-			// 
-			this.lbl_sr_l.AutoSize = true;
-			this.lbl_sr_l.Location = new System.Drawing.Point(15, 104);
-			this.lbl_sr_l.Name = "lbl_sr_l";
-			this.lbl_sr_l.Size = new System.Drawing.Size(80, 13);
-			this.lbl_sr_l.TabIndex = 8;
-			this.lbl_sr_l.Text = "SR Left Joycon";
-			this.lbl_sr_l.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_sr_l
-			// 
-			this.btn_sr_l.Location = new System.Drawing.Point(105, 99);
-			this.btn_sr_l.Name = "btn_sr_l";
-			this.btn_sr_l.Size = new System.Drawing.Size(75, 23);
-			this.btn_sr_l.TabIndex = 7;
-			this.btn_sr_l.UseVisualStyleBackColor = true;
-			// 
-			// lbl_sl_r
-			// 
-			this.lbl_sl_r.AutoSize = true;
-			this.lbl_sl_r.Location = new System.Drawing.Point(15, 133);
-			this.lbl_sl_r.Name = "lbl_sl_r";
-			this.lbl_sl_r.Size = new System.Drawing.Size(85, 13);
-			this.lbl_sl_r.TabIndex = 10;
-			this.lbl_sl_r.Text = "SL Right Joycon";
-			this.lbl_sl_r.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_sl_r
-			// 
-			this.btn_sl_r.Location = new System.Drawing.Point(105, 128);
-			this.btn_sl_r.Name = "btn_sl_r";
-			this.btn_sl_r.Size = new System.Drawing.Size(75, 23);
-			this.btn_sl_r.TabIndex = 9;
-			this.btn_sl_r.UseVisualStyleBackColor = true;
-			// 
-			// lbl_sr_r
-			// 
-			this.lbl_sr_r.AutoSize = true;
-			this.lbl_sr_r.Location = new System.Drawing.Point(15, 162);
-			this.lbl_sr_r.Name = "lbl_sr_r";
-			this.lbl_sr_r.Size = new System.Drawing.Size(87, 13);
-			this.lbl_sr_r.TabIndex = 12;
-			this.lbl_sr_r.Text = "SR Right Joycon";
-			this.lbl_sr_r.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_sr_r
-			// 
-			this.btn_sr_r.Location = new System.Drawing.Point(105, 157);
-			this.btn_sr_r.Name = "btn_sr_r";
-			this.btn_sr_r.Size = new System.Drawing.Size(75, 23);
-			this.btn_sr_r.TabIndex = 11;
-			this.btn_sr_r.UseVisualStyleBackColor = true;
-			// 
-			// btn_close
-			// 
-			this.btn_close.Location = new System.Drawing.Point(15, 257);
-			this.btn_close.Name = "btn_close";
-			this.btn_close.Size = new System.Drawing.Size(75, 23);
-			this.btn_close.TabIndex = 13;
-			this.btn_close.Text = "Okay";
-			this.btn_close.UseVisualStyleBackColor = true;
-			this.btn_close.Click += new System.EventHandler(this.btn_close_Click);
-			// 
-			// btn_apply
-			// 
-			this.btn_apply.Location = new System.Drawing.Point(105, 257);
-			this.btn_apply.Name = "btn_apply";
-			this.btn_apply.Size = new System.Drawing.Size(75, 23);
-			this.btn_apply.TabIndex = 14;
-			this.btn_apply.Text = "Apply";
-			this.btn_apply.UseVisualStyleBackColor = true;
-			this.btn_apply.Click += new System.EventHandler(this.btn_apply_Click);
-			// 
-			// lbl_reset_mouse
-			// 
-			this.lbl_reset_mouse.AutoSize = true;
-			this.lbl_reset_mouse.Location = new System.Drawing.Point(15, 191);
-			this.lbl_reset_mouse.Name = "lbl_reset_mouse";
-			this.lbl_reset_mouse.Size = new System.Drawing.Size(80, 13);
-			this.lbl_reset_mouse.TabIndex = 16;
-			this.lbl_reset_mouse.Text = "Re-Centre Gyro";
-			this.lbl_reset_mouse.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_reset_mouse
-			// 
-			this.btn_reset_mouse.Location = new System.Drawing.Point(105, 186);
-			this.btn_reset_mouse.Name = "btn_reset_mouse";
-			this.btn_reset_mouse.Size = new System.Drawing.Size(75, 23);
-			this.btn_reset_mouse.TabIndex = 15;
-			this.btn_reset_mouse.UseVisualStyleBackColor = true;
-			// 
-			// lbl_activate_gyro
-			// 
-			this.lbl_activate_gyro.AutoSize = true;
-			this.lbl_activate_gyro.Location = new System.Drawing.Point(14, 220);
-			this.lbl_activate_gyro.Name = "lbl_activate_gyro";
-			this.lbl_activate_gyro.Size = new System.Drawing.Size(71, 13);
-			this.lbl_activate_gyro.TabIndex = 17;
-			this.lbl_activate_gyro.Text = "Activate Gyro";
-			this.lbl_activate_gyro.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-			// 
-			// btn_active_gyro
-			// 
-			this.btn_active_gyro.Location = new System.Drawing.Point(105, 215);
-			this.btn_active_gyro.Name = "btn_active_gyro";
-			this.btn_active_gyro.Size = new System.Drawing.Size(75, 23);
-			this.btn_active_gyro.TabIndex = 18;
-			this.btn_active_gyro.UseVisualStyleBackColor = true;
-			// 
-			// Reassign
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(192, 292);
-			this.Controls.Add(this.btn_active_gyro);
-			this.Controls.Add(this.lbl_activate_gyro);
-			this.Controls.Add(this.lbl_reset_mouse);
-			this.Controls.Add(this.btn_reset_mouse);
-			this.Controls.Add(this.btn_apply);
-			this.Controls.Add(this.btn_close);
-			this.Controls.Add(this.lbl_sr_r);
-			this.Controls.Add(this.btn_sr_r);
-			this.Controls.Add(this.lbl_sl_r);
-			this.Controls.Add(this.btn_sl_r);
-			this.Controls.Add(this.lbl_sr_l);
-			this.Controls.Add(this.btn_sr_l);
-			this.Controls.Add(this.lbl_sl_l);
-			this.Controls.Add(this.btn_sl_l);
-			this.Controls.Add(this.lbl_home);
-			this.Controls.Add(this.btn_home);
-			this.Controls.Add(this.lbl_capture);
-			this.Controls.Add(this.btn_capture);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "Reassign";
-			this.Text = "Map Special Buttons";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Reassign_FormClosing);
-			this.Load += new System.EventHandler(this.Reassign_Load);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Reassign));
+            this.btn_capture = new BetterJoyForCemu.SplitButton();
+            this.lbl_capture = new System.Windows.Forms.Label();
+            this.lbl_home = new System.Windows.Forms.Label();
+            this.btn_home = new BetterJoyForCemu.SplitButton();
+            this.lbl_sl_l = new System.Windows.Forms.Label();
+            this.btn_sl_l = new BetterJoyForCemu.SplitButton();
+            this.lbl_sr_l = new System.Windows.Forms.Label();
+            this.btn_sr_l = new BetterJoyForCemu.SplitButton();
+            this.lbl_sl_r = new System.Windows.Forms.Label();
+            this.btn_sl_r = new BetterJoyForCemu.SplitButton();
+            this.lbl_sr_r = new System.Windows.Forms.Label();
+            this.btn_sr_r = new BetterJoyForCemu.SplitButton();
+            this.btn_close = new System.Windows.Forms.Button();
+            this.btn_apply = new System.Windows.Forms.Button();
+            this.tip_reassign = new System.Windows.Forms.ToolTip(this.components);
+            this.lbl_reset_mouse = new System.Windows.Forms.Label();
+            this.btn_reset_mouse = new BetterJoyForCemu.SplitButton();
+            this.lbl_activate_gyro = new System.Windows.Forms.Label();
+            this.btn_active_gyro = new BetterJoyForCemu.SplitButton();
+            this.lbl_shake = new System.Windows.Forms.Label();
+            this.btn_shake = new BetterJoyForCemu.SplitButton();
+            this.SuspendLayout();
+            // 
+            // btn_capture
+            // 
+            this.btn_capture.Location = new System.Drawing.Point(105, 12);
+            this.btn_capture.Name = "btn_capture";
+            this.btn_capture.Size = new System.Drawing.Size(75, 23);
+            this.btn_capture.TabIndex = 0;
+            this.btn_capture.UseVisualStyleBackColor = true;
+            // 
+            // lbl_capture
+            // 
+            this.lbl_capture.AutoSize = true;
+            this.lbl_capture.Location = new System.Drawing.Point(15, 17);
+            this.lbl_capture.Name = "lbl_capture";
+            this.lbl_capture.Size = new System.Drawing.Size(44, 13);
+            this.lbl_capture.TabIndex = 2;
+            this.lbl_capture.Text = "Capture";
+            this.lbl_capture.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // lbl_home
+            // 
+            this.lbl_home.AutoSize = true;
+            this.lbl_home.Location = new System.Drawing.Point(15, 46);
+            this.lbl_home.Name = "lbl_home";
+            this.lbl_home.Size = new System.Drawing.Size(35, 13);
+            this.lbl_home.TabIndex = 4;
+            this.lbl_home.Text = "Home";
+            this.lbl_home.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_home
+            // 
+            this.btn_home.Location = new System.Drawing.Point(105, 41);
+            this.btn_home.Name = "btn_home";
+            this.btn_home.Size = new System.Drawing.Size(75, 23);
+            this.btn_home.TabIndex = 3;
+            this.btn_home.UseVisualStyleBackColor = true;
+            // 
+            // lbl_sl_l
+            // 
+            this.lbl_sl_l.AutoSize = true;
+            this.lbl_sl_l.Location = new System.Drawing.Point(15, 75);
+            this.lbl_sl_l.Name = "lbl_sl_l";
+            this.lbl_sl_l.Size = new System.Drawing.Size(78, 13);
+            this.lbl_sl_l.TabIndex = 6;
+            this.lbl_sl_l.Text = "SL Left Joycon";
+            this.lbl_sl_l.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_sl_l
+            // 
+            this.btn_sl_l.Location = new System.Drawing.Point(105, 70);
+            this.btn_sl_l.Name = "btn_sl_l";
+            this.btn_sl_l.Size = new System.Drawing.Size(75, 23);
+            this.btn_sl_l.TabIndex = 5;
+            this.btn_sl_l.UseVisualStyleBackColor = true;
+            // 
+            // lbl_sr_l
+            // 
+            this.lbl_sr_l.AutoSize = true;
+            this.lbl_sr_l.Location = new System.Drawing.Point(15, 104);
+            this.lbl_sr_l.Name = "lbl_sr_l";
+            this.lbl_sr_l.Size = new System.Drawing.Size(80, 13);
+            this.lbl_sr_l.TabIndex = 8;
+            this.lbl_sr_l.Text = "SR Left Joycon";
+            this.lbl_sr_l.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_sr_l
+            // 
+            this.btn_sr_l.Location = new System.Drawing.Point(105, 99);
+            this.btn_sr_l.Name = "btn_sr_l";
+            this.btn_sr_l.Size = new System.Drawing.Size(75, 23);
+            this.btn_sr_l.TabIndex = 7;
+            this.btn_sr_l.UseVisualStyleBackColor = true;
+            // 
+            // lbl_sl_r
+            // 
+            this.lbl_sl_r.AutoSize = true;
+            this.lbl_sl_r.Location = new System.Drawing.Point(15, 133);
+            this.lbl_sl_r.Name = "lbl_sl_r";
+            this.lbl_sl_r.Size = new System.Drawing.Size(85, 13);
+            this.lbl_sl_r.TabIndex = 10;
+            this.lbl_sl_r.Text = "SL Right Joycon";
+            this.lbl_sl_r.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_sl_r
+            // 
+            this.btn_sl_r.Location = new System.Drawing.Point(105, 128);
+            this.btn_sl_r.Name = "btn_sl_r";
+            this.btn_sl_r.Size = new System.Drawing.Size(75, 23);
+            this.btn_sl_r.TabIndex = 9;
+            this.btn_sl_r.UseVisualStyleBackColor = true;
+            // 
+            // lbl_sr_r
+            // 
+            this.lbl_sr_r.AutoSize = true;
+            this.lbl_sr_r.Location = new System.Drawing.Point(15, 162);
+            this.lbl_sr_r.Name = "lbl_sr_r";
+            this.lbl_sr_r.Size = new System.Drawing.Size(87, 13);
+            this.lbl_sr_r.TabIndex = 12;
+            this.lbl_sr_r.Text = "SR Right Joycon";
+            this.lbl_sr_r.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_sr_r
+            // 
+            this.btn_sr_r.Location = new System.Drawing.Point(105, 157);
+            this.btn_sr_r.Name = "btn_sr_r";
+            this.btn_sr_r.Size = new System.Drawing.Size(75, 23);
+            this.btn_sr_r.TabIndex = 11;
+            this.btn_sr_r.UseVisualStyleBackColor = true;
+            // 
+            // btn_close
+            // 
+            this.btn_close.Location = new System.Drawing.Point(15, 289);
+            this.btn_close.Name = "btn_close";
+            this.btn_close.Size = new System.Drawing.Size(75, 23);
+            this.btn_close.TabIndex = 13;
+            this.btn_close.Text = "Okay";
+            this.btn_close.UseVisualStyleBackColor = true;
+            this.btn_close.Click += new System.EventHandler(this.btn_close_Click);
+            // 
+            // btn_apply
+            // 
+            this.btn_apply.Location = new System.Drawing.Point(105, 289);
+            this.btn_apply.Name = "btn_apply";
+            this.btn_apply.Size = new System.Drawing.Size(75, 23);
+            this.btn_apply.TabIndex = 14;
+            this.btn_apply.Text = "Apply";
+            this.btn_apply.UseVisualStyleBackColor = true;
+            this.btn_apply.Click += new System.EventHandler(this.btn_apply_Click);
+            // 
+            // lbl_reset_mouse
+            // 
+            this.lbl_reset_mouse.AutoSize = true;
+            this.lbl_reset_mouse.Location = new System.Drawing.Point(15, 223);
+            this.lbl_reset_mouse.Name = "lbl_reset_mouse";
+            this.lbl_reset_mouse.Size = new System.Drawing.Size(80, 13);
+            this.lbl_reset_mouse.TabIndex = 16;
+            this.lbl_reset_mouse.Text = "Re-Centre Gyro";
+            this.lbl_reset_mouse.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_reset_mouse
+            // 
+            this.btn_reset_mouse.Location = new System.Drawing.Point(105, 218);
+            this.btn_reset_mouse.Name = "btn_reset_mouse";
+            this.btn_reset_mouse.Size = new System.Drawing.Size(75, 23);
+            this.btn_reset_mouse.TabIndex = 15;
+            this.btn_reset_mouse.UseVisualStyleBackColor = true;
+            // 
+            // lbl_activate_gyro
+            // 
+            this.lbl_activate_gyro.AutoSize = true;
+            this.lbl_activate_gyro.Location = new System.Drawing.Point(14, 252);
+            this.lbl_activate_gyro.Name = "lbl_activate_gyro";
+            this.lbl_activate_gyro.Size = new System.Drawing.Size(71, 13);
+            this.lbl_activate_gyro.TabIndex = 17;
+            this.lbl_activate_gyro.Text = "Activate Gyro";
+            this.lbl_activate_gyro.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // btn_active_gyro
+            // 
+            this.btn_active_gyro.Location = new System.Drawing.Point(105, 247);
+            this.btn_active_gyro.Name = "btn_active_gyro";
+            this.btn_active_gyro.Size = new System.Drawing.Size(75, 23);
+            this.btn_active_gyro.TabIndex = 18;
+            this.btn_active_gyro.UseVisualStyleBackColor = true;
+            // 
+            // label1
+            // 
+            this.lbl_shake.AutoSize = true;
+            this.lbl_shake.Location = new System.Drawing.Point(15, 191);
+            this.lbl_shake.Name = "lbl_shake";
+            this.lbl_shake.Size = new System.Drawing.Size(87, 13);
+            this.lbl_shake.TabIndex = 20;
+            this.lbl_shake.Text = "Shake Input";
+            this.lbl_shake.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
+            // splitButton1
+            // 
+            this.btn_shake.Location = new System.Drawing.Point(105, 186);
+            this.btn_shake.Name = "btn_shake";
+            this.btn_shake.Size = new System.Drawing.Size(75, 23);
+            this.btn_shake.TabIndex = 19;
+            this.btn_shake.UseVisualStyleBackColor = true;
+            // 
+            // Reassign
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(192, 338);
+            this.Controls.Add(this.lbl_shake);
+            this.Controls.Add(this.btn_shake);
+            this.Controls.Add(this.btn_active_gyro);
+            this.Controls.Add(this.lbl_activate_gyro);
+            this.Controls.Add(this.lbl_reset_mouse);
+            this.Controls.Add(this.btn_reset_mouse);
+            this.Controls.Add(this.btn_apply);
+            this.Controls.Add(this.btn_close);
+            this.Controls.Add(this.lbl_sr_r);
+            this.Controls.Add(this.btn_sr_r);
+            this.Controls.Add(this.lbl_sl_r);
+            this.Controls.Add(this.btn_sl_r);
+            this.Controls.Add(this.lbl_sr_l);
+            this.Controls.Add(this.btn_sr_l);
+            this.Controls.Add(this.lbl_sl_l);
+            this.Controls.Add(this.btn_sl_l);
+            this.Controls.Add(this.lbl_home);
+            this.Controls.Add(this.btn_home);
+            this.Controls.Add(this.lbl_capture);
+            this.Controls.Add(this.btn_capture);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "Reassign";
+            this.Text = "Map Special Buttons";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Reassign_FormClosing);
+            this.Load += new System.EventHandler(this.Reassign_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -323,5 +345,7 @@ namespace BetterJoyForCemu {
 		private SplitButton btn_reset_mouse;
 		private Label lbl_activate_gyro;
 		private SplitButton btn_active_gyro;
-	}
+        private Label lbl_shake;
+        private SplitButton btn_shake;
+    }
 }

--- a/BetterJoyForCemu/Reassign.cs
+++ b/BetterJoyForCemu/Reassign.cs
@@ -29,7 +29,7 @@ namespace BetterJoyForCemu {
 
             menu_joy_buttons.ItemClicked += Menu_joy_buttons_ItemClicked;
 
-            foreach (SplitButton c in new SplitButton[] { btn_capture, btn_home, btn_sl_l, btn_sl_r, btn_sr_l, btn_sr_r, btn_reset_mouse, btn_active_gyro }) {
+            foreach (SplitButton c in new SplitButton[] { btn_capture, btn_home, btn_sl_l, btn_sl_r, btn_sr_l, btn_sr_r, btn_shake, btn_reset_mouse, btn_active_gyro }) {
                 c.Tag = c.Name.Substring(4);
                 GetPrettyName(c);
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Go to the [Releases tab](https://github.com/Davidobot/BetterJoy/releases/)!
     1. Read the READMEs (they're there for a reason!)
     1. Run *Drivers/ViGEmBus_Setup_1.16.116.exe*
 2. Run *BetterJoyForCemu.exe* 
-    (Run as Administrator if your keyboard/mouse button mappings don't work)
+    1. (Run as Administrator if your keyboard/mouse button mappings don't work)
 3. Connect your controllers.
 4. Start Cemu and ensure CemuHook has the controller selected.
     1. If using Joycons, CemuHook will detect two controllers - each will give all buttons, but choosing one over the other just chooses preference for which hand to use for gyro controls.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Go to the [Releases tab](https://github.com/Davidobot/BetterJoy/releases/)!
 1. Install drivers
     1. Read the READMEs (they're there for a reason!)
     1. Run *Drivers/ViGEmBus_Setup_1.16.116.exe*
-2. Run *BetterJoyForCemu.exe*
+2. Run *BetterJoyForCemu.exe* (Run as Administrator if your mapped special buttons don't work.)
 3. Connect your controllers.
 4. Start Cemu and ensure CemuHook has the controller selected.
     1. If using Joycons, CemuHook will detect two controllers - each will give all buttons, but choosing one over the other just chooses preference for which hand to use for gyro controls.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Go to the [Releases tab](https://github.com/Davidobot/BetterJoy/releases/)!
 1. Install drivers
     1. Read the READMEs (they're there for a reason!)
     1. Run *Drivers/ViGEmBus_Setup_1.16.116.exe*
-2. Run *BetterJoyForCemu.exe* (Run as Administrator if your mapped special buttons don't work.)
+2. Run *BetterJoyForCemu.exe* 
+    (Run as Administrator if your keyboard/mouse button mappings don't work)
 3. Connect your controllers.
 4. Start Cemu and ensure CemuHook has the controller selected.
     1. If using Joycons, CemuHook will detect two controllers - each will give all buttons, but choosing one over the other just chooses preference for which hand to use for gyro controls.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Go to the [Releases tab](https://github.com/Davidobot/BetterJoy/releases/)!
     1. Read the READMEs (they're there for a reason!)
     1. Run *Drivers/ViGEmBus_Setup_1.16.116.exe*
 2. Run *BetterJoyForCemu.exe* 
-    1. (Run as Administrator if your keyboard/mouse button mappings don't work)
+    1. Run as Administrator if your keyboard/mouse button mappings don't work
 3. Connect your controllers.
 4. Start Cemu and ensure CemuHook has the controller selected.
     1. If using Joycons, CemuHook will detect two controllers - each will give all buttons, but choosing one over the other just chooses preference for which hand to use for gyro controls.


### PR DESCRIPTION
Adds support for a Shake input.

Tested with the Switch pro controller.
Needs to be tested with Joy-cons

Only supports DS4 because Xinput does not have any free buttons to use.
Remaps the Touchpad input (Button 13 on DirectInput) to use the new Shake input.

Added 3 new options to settings:
 1. Enable the shake input.
 2. Change the shake detection sensitivity.
 3. Change how often the shake input can run.

