### PR TITLE
Rumble data processing refactor

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -13,9 +13,6 @@
         <!--Whether the Motion Server is enabled or not. Default: true -->
         <add key="MotionServer" value="true" />
 
-        <!--Rumble motor period in millisec. Lower means more granular vibration, higher is more stable.-->
-        <!--The response of rumble does not only depend on this setting and it's always high. Default: 300 -->
-        <add key="RumblePeriod" value="300" />
         <!--The controller's HD rumble settings for the low/high frequency rumble. Change to change the pitch of the rumble.-->
         <!--Don't set above ~1200. Default: 40 and 120 -->
         <!--To have "stronger" rumble, try setting the low/high to 160/320-->

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -245,7 +245,7 @@ namespace BetterJoyForCemu {
             handle = handle_;
             imu_enabled = imu;
             do_localize = localize;
-            rumble_obj = new Rumble(new float[] { lowFreq, highFreq, 0 });
+            rumble_obj = new Rumble(new float[] { lowFreq, highFreq, 0});
             for (int i = 0; i < buttons_down_timestamp.Length; i++)
                 buttons_down_timestamp[i] = -1;
             filterweight = alpha;

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -126,7 +126,7 @@ namespace BetterJoyForCemu {
             public Queue<float[]> queue;
 
             public void set_vals(float low_freq, float high_freq, float amplitude) {
-                float[] rumbleQueue = new float[] { low_freq, high_freq, amplitude };
+                float[] rumbleQueue = new float[] {low_freq, high_freq, amplitude};
                 queue.Enqueue(rumbleQueue);
             }
             public Rumble(float[] rumble_info) {
@@ -245,7 +245,7 @@ namespace BetterJoyForCemu {
             handle = handle_;
             imu_enabled = imu;
             do_localize = localize;
-            rumble_obj = new Rumble(new float[] { lowFreq, highFreq, 0});
+            rumble_obj = new Rumble(new float[] {lowFreq, highFreq, 0});
             for (int i = 0; i < buttons_down_timestamp.Length; i++)
                 buttons_down_timestamp[i] = -1;
             filterweight = alpha;

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -138,9 +138,6 @@ namespace BetterJoyForCemu {
                 if (x > max) return max;
                 return x;
             }
-            public void Update() {
-                //Unused
-            }
 
             private byte EncodeAmp(float amp) {
                 byte en_amp;

--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -141,7 +141,7 @@ namespace BetterJoyForCemu {
         bool showAsXInput = Boolean.Parse(ConfigurationManager.AppSettings["ShowAsXInput"]);
         bool showAsDS4 = Boolean.Parse(ConfigurationManager.AppSettings["ShowAsDS4"]);
 
-        public void locBtnClick(object sender, EventArgs e) {
+        public async void locBtnClickAsync(object sender, EventArgs e) {
             Button bb = sender as Button;
 
             if (bb.Tag.GetType() == typeof(Button)) {
@@ -149,7 +149,9 @@ namespace BetterJoyForCemu {
 
                 if (button.Tag.GetType() == typeof(Joycon)) {
                     Joycon v = (Joycon)button.Tag;
-                    v.SetRumble(160.0f, 320.0f, 1.0f, 300);
+                    v.SetRumble(160.0f, 320.0f, 1.0f);
+                    await Task.Delay(300);
+                    v.SetRumble(160.0f, 320.0f, 0);
                 }
             }
         }

--- a/BetterJoyForCemu/Program.cs
+++ b/BetterJoyForCemu/Program.cs
@@ -229,7 +229,7 @@ namespace BetterJoyForCemu {
 
                                 form.loc[ii].Invoke(new MethodInvoker(delegate {
                                     form.loc[ii].Tag = v;
-                                    form.loc[ii].Click += new EventHandler(form.locBtnClick);
+                                    form.loc[ii].Click += new EventHandler(form.locBtnClickAsync);
                                 }));
 
                                 break;


### PR DESCRIPTION
## Reimplement Rumble data proccesing.
This aims to fix issues where BetterJoy would lose rumble packets due to many packets being received at very short intervals (sub 6 ms) which would cause the rumble to not rumble at all or would not stop rumbling.

### Use a queue.
This PR fixes this issue by adding a Queue/Buffer for the rumble packets enabling BetterJoy to process the data properly and in the correct order.
It also removes the need to have a `Rumble Delay` setting because it will start and stop the rumble according to the data received.

### Other changes
Since the configurable rumble duration is not available anymore, the `Locate` button will use a delay to set the Rumble.
 