### PR TITLE
Do not connect Joycons that are already paired. Fix concurrent modification crash.

### DIFF
--- a/BetterJoyForCemu/BetterJoy.csproj
+++ b/BetterJoyForCemu/BetterJoy.csproj
@@ -130,6 +130,7 @@
     <Compile Include="3rdPartyControllers.Designer.cs">
       <DependentUpon>3rdPartyControllers.cs</DependentUpon>
     </Compile>
+    <Compile Include="Collections\ConcurrentList.cs" />
     <Compile Include="Config.cs" />
     <Compile Include="Controller\OutputControllerDualShock4.cs" />
     <Compile Include="Controller\OutputControllerXbox360.cs" />

--- a/BetterJoyForCemu/Collections/ConcurrentList.cs
+++ b/BetterJoyForCemu/Collections/ConcurrentList.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace BetterJoyForCemu.Collections {
+
+    // https://codereview.stackexchange.com/a/125341
+    public class ConcurrentList<T> : IList<T> {
+        #region Fields
+
+        private IList<T> _internalList;
+
+        private readonly object lockObject = new object();
+
+        #endregion
+
+        #region ctor
+
+        public ConcurrentList() {
+            _internalList = new List<T>();
+        }
+
+        public ConcurrentList(int capacity) {
+            _internalList = new List<T>(capacity);
+        }
+
+        public ConcurrentList(IEnumerable<T> list) {
+            _internalList = new List<T>();
+            foreach (T item in list) {
+                _internalList.Add(item);
+            }
+        }
+
+        #endregion
+
+        public T this[int index] {
+            get {
+                return LockInternalListAndGet(l => l[index]);
+            }
+
+            set {
+                LockInternalListAndCommand(l => l[index] = value);
+            }
+        }
+
+        public int Count {
+            get {
+                return LockInternalListAndQuery(l => l.Count);
+            }
+        }
+
+        public bool IsReadOnly => false;
+
+        public void Add(T item) {
+            LockInternalListAndCommand(l => l.Add(item));
+        }
+
+        public void Clear() {
+            LockInternalListAndCommand(l => l.Clear());
+        }
+
+        public bool Contains(T item) {
+            return LockInternalListAndQuery(l => l.Contains(item));
+        }
+
+        public void CopyTo(T[] array, int arrayIndex) {
+            LockInternalListAndCommand(l => l.CopyTo(array, arrayIndex));
+        }
+
+        public IEnumerator<T> GetEnumerator() {
+            return LockInternalListAndQuery(l => l.GetEnumerator());
+        }
+
+        public int IndexOf(T item) {
+            return LockInternalListAndQuery(l => l.IndexOf(item));
+        }
+
+        public void Insert(int index, T item) {
+            LockInternalListAndCommand(l => l.Insert(index, item));
+        }
+
+        public bool Remove(T item) {
+            return LockInternalListAndQuery(l => l.Remove(item));
+        }
+
+        public void RemoveAt(int index) {
+            LockInternalListAndCommand(l => l.RemoveAt(index));
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return LockInternalListAndQuery(l => l.GetEnumerator());
+        }
+
+        #region Utilities
+
+        protected virtual void LockInternalListAndCommand(Action<IList<T>> action) {
+            lock (lockObject) {
+                action(_internalList);
+            }
+        }
+
+        protected virtual T LockInternalListAndGet(Func<IList<T>, T> func) {
+            lock (lockObject) {
+                return func(_internalList);
+            }
+        }
+
+        protected virtual TObject LockInternalListAndQuery<TObject>(Func<IList<T>, TObject> query) {
+            lock (lockObject) {
+                return query(_internalList);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -17,7 +17,7 @@ namespace BetterJoyForCemu {
         public bool isPro = false;
         public bool isSnes = false;
         bool isUSB = false;
-        public Joycon other;
+        public Joycon other = null;
         public bool active_gyro = false;
 
         private long inactivity = Stopwatch.GetTimestamp();

--- a/BetterJoyForCemu/UpdServer.cs
+++ b/BetterJoyForCemu/UpdServer.cs
@@ -17,7 +17,7 @@ namespace BetterJoyForCemu {
 
         public MainForm form;
 
-        public UdpServer(List<Joycon> p) {
+        public UdpServer(IList<Joycon> p) {
             controllers = p;
         }
 


### PR DESCRIPTION
Connecting 4 Joycons presented issues.

The first two pair successfully, then the third would sit idle as the fourth connected Joycon would connect to the first.
The on-connect pairing will now correctly ignore a Joycon if it is already paired/connected to another Joycon.

This also fixes crashes when using 3-4+ Joycons as the List implementation did not previously support multiple threaded access.