### PR TITLE
used serial_number to identify and set type to a specific device

### DIFF
--- a/BetterJoyForCemu/3rdPartyControllers.cs
+++ b/BetterJoyForCemu/3rdPartyControllers.cs
@@ -18,10 +18,12 @@ namespace BetterJoyForCemu {
             public String name;
             public ushort product_id;
             public ushort vendor_id;
+            public string serial_number;
             public byte type; // 1 is pro, 2 is left joy, 3 is right joy
 
-            public SController(String name, ushort vendor_id, ushort product_id, byte type) {
+            public SController(String name, ushort vendor_id, ushort product_id, byte type, string serial_number) {
                 this.product_id = product_id; this.vendor_id = vendor_id; this.type = type;
+                this.serial_number = serial_number;
                 this.name = name;
             }
 
@@ -31,12 +33,12 @@ namespace BetterJoyForCemu {
                     return false;
                 } else {
                     SController s = (SController)obj;
-                    return (s.product_id == product_id) && (s.vendor_id == vendor_id);
+                    return (s.product_id == product_id) && (s.vendor_id == vendor_id) && (s.serial_number == serial_number);
                 }
             }
 
             public override int GetHashCode() {
-                return Tuple.Create(product_id, vendor_id).GetHashCode();
+                return Tuple.Create(product_id, vendor_id, serial_number).GetHashCode();
             }
 
             public override string ToString() {
@@ -44,7 +46,7 @@ namespace BetterJoyForCemu {
             }
 
             public string Serialise() {
-                return String.Format("{0}|{1}|{2}|{3}", name, vendor_id, product_id, type);
+                return String.Format("{0}|{1}|{2}|{3}|{4}", name, vendor_id, product_id, type, serial_number);
             }
         }
 
@@ -69,7 +71,12 @@ namespace BetterJoyForCemu {
                     string line = String.Empty;
                     while ((line = file.ReadLine()) != null && (line != String.Empty)) {
                         String[] split = line.Split('|');
-                        list_customControllers.Items.Add(new SController(split[0], ushort.Parse(split[1]), ushort.Parse(split[2]), byte.Parse(split[3])));
+                        //won't break existing config file
+                        String serial_number = "";
+                        if (split.Length > 4) {
+                            serial_number = split[4];
+                        }
+                        list_customControllers.Items.Add(new SController(split[0], ushort.Parse(split[1]), ushort.Parse(split[2]), byte.Parse(split[3]), serial_number));
                     }
                 }
             }
@@ -112,10 +119,11 @@ namespace BetterJoyForCemu {
                 }
 
                 // TODO: try checking against interface number instead
-                String name = enumerate.product_string + '(' + enumerate.vendor_id + '-' + enumerate.product_id + ')';
+                String name = enumerate.product_string + '(' + enumerate.vendor_id + '-' + enumerate.product_id + '-'+enumerate.serial_number+')';
                 if (!ContainsText(list_customControllers, name) && !ContainsText(list_allControllers, name)) {
-                    list_allControllers.Items.Add(new SController(name, enumerate.vendor_id, enumerate.product_id, 0));
+                    list_allControllers.Items.Add(new SController(name, enumerate.vendor_id, enumerate.product_id, 0, enumerate.serial_number));
                     // 0 type is undefined
+                    Console.WriteLine("Found controller "+ name);
                 }
 
                 ptr = enumerate.next;

--- a/BetterJoyForCemu/Program.cs
+++ b/BetterJoyForCemu/Program.cs
@@ -134,7 +134,7 @@ namespace BetterJoyForCemu {
                                         enumerate.product_id == product_pro || enumerate.product_id == product_snes) && enumerate.vendor_id == vendor_id;
                 // check list of custom controllers specified
                 foreach (SController v in Program.thirdPartyCons) {
-                    if (enumerate.vendor_id == v.vendor_id && enumerate.product_id == v.product_id) {
+                    if (enumerate.vendor_id == v.vendor_id && enumerate.product_id == v.product_id && enumerate.serial_number == v.serial_number) {
                         validController = true;
                         thirdParty = v;
                         break;


### PR DESCRIPTION
This fixes the ability to [change the type of a 3rd party JoyCon](https://github.com/Davidobot/BetterJoy/issues/646) as described also [here](https://github.com/Davidobot/BetterJoy/issues/588#issuecomment-758769386).

I noticed that 3rd party joycons (in my case joysky "wireless controller for N/SW") reported the same name "wireless gamepad" and vendor id to windows for Left and Right Joycon. 
BetterJoy is using this args for generating a unique id for 3rdParty configuration that results the same for Left/Right.

**3rdPartyControllers** file content in **6.4a version**:
_Wireless Gamepad|1406|8201|2
Wireless Gamepad|1406|8201|3_


**3rdPartyControllers** file content in **current master**:
_Wireless Gamepad(1406-8201)|1406|8201|2
Wireless Gamepad(1406-8201)|1406|8201|3_

In both cases the first joycon is assigning 2 as type to the other joycon.

By **using bluetooth serial number as additional identifier** we can target specific device with correct type:
_Wireless Gamepad(1406-8201-98b6e99a9c77)|1406|8201|2|98b6e99a9c77
Wireless Gamepad(1406-8201-98b6e904ea9e)|1406|8201|3|98b6e904ea9e_

**Changes:**
- used serial_number as additional condition in "check list of custom controllers specified" block
- SController now incapsulate serial_number and use it for hash, equals, serialize etc
- Read the 5 index of 3rdPartyController file on _3rdPartyControllers

This pull request in addition to **"NonOriginalController"="DefaultCalibration"** (as [suggested here](https://github.com/Davidobot/BetterJoy/issues/590)) fixed my 3rdParty joycons.

P.S. This is my first attempt on C#, so be kind to me and I'm opened toy suggestions.