### PR TITLE
Fix DS4 L2 / R2 not working in many games and remap capture -> share / minus -> touchpad

### DIFF
--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -1460,10 +1460,10 @@ namespace BetterJoyForCemu {
                 else if (buttons[(int)Button.DPAD_RIGHT])
                     output.dPad = DpadDirection.East;
 
-                output.share = buttons[(int)Button.MINUS];
+                output.share = buttons[(int)Button.CAPTURE];
                 output.options = buttons[(int)Button.PLUS];
                 output.ps = buttons[(int)Button.HOME];
-                output.touchpad = buttons[(int)Button.CAPTURE];
+                output.touchpad = buttons[(int)Button.MINUS];
                 output.shoulder_left = buttons[(int)Button.SHOULDER_1];
                 output.shoulder_right = buttons[(int)Button.SHOULDER2_1];
                 output.thumb_left = buttons[(int)Button.STICK];
@@ -1494,10 +1494,10 @@ namespace BetterJoyForCemu {
                     else if (buttons[(int)(isLeft ? Button.DPAD_RIGHT : Button.A)])
                         output.dPad = DpadDirection.East;
 
-                    output.share = buttons[(int)Button.MINUS];
+                    output.share = buttons[(int)Button.CAPTURE];
                     output.options = buttons[(int)Button.PLUS];
                     output.ps = buttons[(int)Button.HOME];
-                    output.touchpad = buttons[(int)Button.CAPTURE];
+                    output.touchpad = buttons[(int)Button.MINUS];
                     output.shoulder_left = buttons[(int)(isLeft ? Button.SHOULDER_1 : Button.SHOULDER2_1)];
                     output.shoulder_right = buttons[(int)(isLeft ? Button.SHOULDER2_1 : Button.SHOULDER_1)];
                     output.thumb_left = buttons[(int)(isLeft ? Button.STICK : Button.STICK2)];
@@ -1543,6 +1543,9 @@ namespace BetterJoyForCemu {
                 output.trigger_left_value = (byte)(buttons[(int)(isLeft ? Button.SHOULDER_2 : Button.SHOULDER_1)] ? Byte.MaxValue : 0);
                 output.trigger_right_value = (byte)(buttons[(int)(isLeft ? Button.SHOULDER_1 : Button.SHOULDER_2)] ? Byte.MaxValue : 0);
             }
+            // Output digital L2 / R2 in addition to analog L2 / R2
+            output.trigger_left = output.trigger_left_value > 0 ? output.trigger_left = true : output.trigger_left = false;
+            output.trigger_right = output.trigger_right_value > 0 ? output.trigger_right = true : output.trigger_right = false;
 
             return output;
         }


### PR DESCRIPTION
These changes perform 2 functions:

- Fix Dualshock 4 outputs ZL -> L2 and ZR -> R2 not working in many games (implement digital buttons) - the issue here was that on a real DS4, the L2 / R2 triggers are both analog _and_ digital.  They throw analog axis values until they are nearly fully depressed, then they _also_ fire a digital button when they are fully depressed.  The current implementation prior to this pull request does not ever fire the digital buttons, which makes many games, which only poll for the digital trigger buttons, to not see the triggers as pulled (as an example, web-slinging in Spider-Man, or grabbing your pack in Death Stranding).  Fixes https://github.com/Davidobot/BetterJoy/issues/715 and https://github.com/Davidobot/BetterJoy/issues/559.


- Remap "Capture" button in Pro Controller / combined JoyCon cases to PS Share, and Minus -> Touchpad press, as is more logical, given the purpose of the capture button is to take a screenshot / share it, and the minus button is closer to the left thumb, which is important given its use as pause / menu in many PS4 / PS5 games (remote play).  Resolves https://github.com/Davidobot/BetterJoy/issues/735.