### PR TITLE
Added Manual Stick Calibration

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -46,6 +46,7 @@
         <!-- When enabled, can only calibrate one controller at a time.-->
         <!-- Default: false -->
         <add key="AllowCalibration" value="false" />
+        <add key="ManualStickCal" value="false" />
         <!-- Default calibration; used for third party controller -->
         <add key="acc_sensiti" value="16384,16384,16384"/>
         <add key="gyr_sensiti" value="18642,18642,18642"/>

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -1169,7 +1169,7 @@ namespace BetterJoyForCemu {
         }
 
         private void dump_calibration_data() {
-            if (isSnes || thirdParty) {
+            if (isSnes || thirdParty || form.ManualStickCal) {
                 short[] temp = (short[])ConfigurationManager.AppSettings["acc_sensiti"].Split(',').Select(s => short.Parse(s)).ToArray();
                 acc_sensiti[0] = temp[0]; acc_sensiti[1] = temp[1]; acc_sensiti[2] = temp[2];
                 temp = (short[])ConfigurationManager.AppSettings["gyr_sensiti"].Split(',').Select(s => short.Parse(s)).ToArray();

--- a/BetterJoyForCemu/MainForm.cs
+++ b/BetterJoyForCemu/MainForm.cs
@@ -16,6 +16,7 @@ using System.Xml.Linq;
 namespace BetterJoyForCemu {
     public partial class MainForm : Form {
         public bool allowCalibration = Boolean.Parse(ConfigurationManager.AppSettings["AllowCalibration"]);
+        public bool ManualStickCal = Boolean.Parse(ConfigurationManager.AppSettings["ManualStickCal"]);
         public List<Button> con, loc;
         public bool calibrate;
         public List<KeyValuePair<string, float[]>> caliData;


### PR DESCRIPTION
Manual Stick Calibration is added for Fake Joy Cons, which have a bug when calibrating. This bug causes a drift stick and this new feature can help solve it.