### PR TITLE
Scale XY coordinates according to new StickScalingFactor configuratio…

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -54,6 +54,10 @@
         <add key="stick2_cal" value="0x780,0x780,0x780,0x830,0x780,0x780"/>
         <add key="deadzone2" value="200"/>
 
+        <!-- Scales the xy coordinates each of the joysticks report. Increase this if you can't push the stick to its maximum. -->
+        <add key="StickScalingFactor" value="1.00" />
+        <add key="StickScalingFactor2" value="1.00" />
+
         <!-- Allows use of gyroscope tilting to get full control of the slider values (big triggers)-->
         <!-- Works on pro controller and joined joycons (pro controller case - triggers combined, joycons case - separate tilt)-->
         <!-- Default: false -->


### PR DESCRIPTION
…n option. Closes #630

I've had an issue with Dark Souls Remastered where my old left joycon wasn't always satisfying its notion of a "running stick push", so my character was walking stealth-like all the time.

To solve this, I've added config options to scale the XY coordinates outward.

The game now lets me run, which is neat!

I'm not sure about two things in this PR:

 - I've added `StickScalingFactor` and `StickScalingFactor2` configuration options, but someone getting a new release won't have them in their current XML config file.
 - I didn't test the "isPro" branch since I don't have a pro controller, so I'm not sure that it pertains to the right stick.

Thanks a lot for this project, I've been having lots of fun and didn't need to get a controller just for the PC!