### PR TITLE
Add support for multiple keys

### DIFF
--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -636,14 +636,27 @@ namespace BetterJoyForCemu {
         Dictionary<int, bool> mouse_toggle_btn = new Dictionary<int, bool>();
         private void Simulate(string s, bool click = true, bool up = false) {
             if (s.StartsWith("key_")) {
-                WindowsInput.Events.KeyCode key = (WindowsInput.Events.KeyCode)Int32.Parse(s.Substring(4));
-                if (click) {
-                    WindowsInput.Simulate.Events().Click(key).Invoke();
-                } else {
-                    if (up) {
-                        WindowsInput.Simulate.Events().Release(key).Invoke();
+                if (s.Contains(",")) {
+                    List<WindowsInput.Events.KeyCode> keys = s.Substring(4).Split(',').Select(x => (WindowsInput.Events.KeyCode)Int32.Parse(x)).ToList();
+                    if (click) {
+                        WindowsInput.Simulate.Events().ClickChord(keys).Invoke();
                     } else {
-                        WindowsInput.Simulate.Events().Hold(key).Invoke();
+                        if (up) {
+                            WindowsInput.Simulate.Events().Release(keys).Invoke();
+                        } else {
+                            WindowsInput.Simulate.Events().Hold(keys).Invoke();
+                        }
+                    }
+                } else {
+                    WindowsInput.Events.KeyCode key = (WindowsInput.Events.KeyCode)Int32.Parse(s.Substring(4));
+                    if (click) {
+                        WindowsInput.Simulate.Events().Click(key).Invoke();
+                    } else {
+                        if (up) {
+                            WindowsInput.Simulate.Events().Release(key).Invoke();
+                        } else {
+                            WindowsInput.Simulate.Events().Hold(key).Invoke();
+                        }
                     }
                 }
             } else if (s.StartsWith("mse_")) {


### PR DESCRIPTION
If the key setting contains “,”, then press multiple keys at the same time.

This feature can be used for the `CAPTURE` button. On my Windows 10 PC, using the `PrintScreen` key will open the “[Snipping Tool](https://apps.microsoft.com/store/detail/snipping-tool/9MZ95KL8MR0L)” app instead of directly taking a screenshot and saving it like Nintendo switch, which is inconvenient for me.

Fortunately, the “[Xbox Game Bar](https://apps.microsoft.com/store/detail/xbox-game-bar/9NZKPSTSNW4P)” app can take a screenshot and save it directly, but it must use multiple keys. The default setting is `Alt + Windows + PrintScreen`.

Therefore, I hope to add this feature, so that I can directly take a screenshot and save it when I press the `CAPTURE` button of my Joy-Con.

Works well on my own PC, using settings `capture key_164,91,44`.