### PR TITLE
Add in swapping A/B and X/Y when holding ZR for Hogwarts Legacy spellcasting

### DIFF
--- a/BetterJoyForCemu/App.config
+++ b/BetterJoyForCemu/App.config
@@ -40,7 +40,10 @@
         <!--Also swaps buttons when using "Also use for buttons/axes"-->
         <!--On is "true"; off is "false". Default: false -->
         <add key="SwapXY" value="false" />
-
+        <!--Swap A-B/X-Y buttons when ZR is held; useful for hogwarts legacy if on, this mimicks the (other half of) Xbox layout by the button name, rather than by the physical layout.-->
+        <!--Also swaps buttons when using "Also use for buttons/axes"-->
+        <!--On is "true"; off is "false". Default: false -->
+        <add key="SwapSpells" value="false" />
         <!-- Allows for calibration of the controller's gyro. Adds a "Calibrate" button.-->
         <!-- When "true", click the "Calibrate" button once to get gyro calibrate data.-->
         <!-- When enabled, can only calibrate one controller at a time.-->

--- a/BetterJoyForCemu/Joycon.cs
+++ b/BetterJoyForCemu/Joycon.cs
@@ -891,6 +891,7 @@ namespace BetterJoyForCemu {
 
         bool swapAB = Boolean.Parse(ConfigurationManager.AppSettings["SwapAB"]);
         bool swapXY = Boolean.Parse(ConfigurationManager.AppSettings["SwapXY"]);
+        bool swapSpells = Boolean.Parse(ConfigurationManager.AppSettings["SwapSpells"]);
         float stickScalingFactor = float.Parse(ConfigurationManager.AppSettings["StickScalingFactor"]);
         float stickScalingFactor2 = float.Parse(ConfigurationManager.AppSettings["StickScalingFactor2"]);
 
@@ -1330,6 +1331,7 @@ namespace BetterJoyForCemu {
 
             var swapAB = input.swapAB;
             var swapXY = input.swapXY;
+            var swapSpells = input.swapSpells;
 
             var isPro = input.isPro;
             var isLeft = input.isLeft;
@@ -1343,6 +1345,10 @@ namespace BetterJoyForCemu {
             var sliderVal = input.sliderVal;
 
             if (isPro) {
+                if (output.trigger_right > 0 & swapSpells) {
+                    swapAB = !swapAB;
+                    swapXY = !swapXY;
+                }
                 output.a = buttons[(int)(!swapAB ? Button.B : Button.A)];
                 output.b = buttons[(int)(!swapAB ? Button.A : Button.B)];
                 output.y = buttons[(int)(!swapXY ? Button.X : Button.Y)];
@@ -1434,6 +1440,7 @@ namespace BetterJoyForCemu {
 
             var swapAB = input.swapAB;
             var swapXY = input.swapXY;
+            var swapSpells = input.swapSpells;
 
             var isPro = input.isPro;
             var isLeft = input.isLeft;
@@ -1447,6 +1454,10 @@ namespace BetterJoyForCemu {
             var sliderVal = input.sliderVal;
 
             if (isPro) {
+                if (output.trigger_right > 0 & swapSpells) {
+                    swapAB = !swapAB;
+                    swapXY = !swapXY;
+                }
                 output.cross = buttons[(int)(!swapAB ? Button.B : Button.A)];
                 output.circle = buttons[(int)(!swapAB ? Button.A : Button.B)];
                 output.triangle = buttons[(int)(!swapXY ? Button.X : Button.Y)];


### PR DESCRIPTION
In the game Hogwarts Legacy, you hold ZR + a button to cast a spell.

Typically this is implemented with Steam inputs to swap the buttons around when holding it down so it matches the spell inputs on-screen positions, but having the feature in BetterJoy makes it work great with the game without using Steam Big Pictures (which IMO is bad)